### PR TITLE
feat: add name to cctCalc and make wte optional

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -64,6 +64,7 @@ components:
       type: object
       required:
        - traineeTisId
+       - name
        - programmeMembership
        - changes
       properties:
@@ -74,6 +75,10 @@ components:
         traineeTisId:
           type: string
           example: "47165"
+        name:
+          description: A custom name for the calculation to aid identification.
+          type: string
+          example: "Parental leave + reduced hours"
         programmeMembership:
           $ref: "#/components/schemas/programmeMembership"
         changes:
@@ -86,7 +91,6 @@ components:
       required:
        - type
        - startDate
-       - endDate
       properties:
         type:
           type: string


### PR DESCRIPTION
Update `cctCalculation` schema to allow a custom name for the calculation. This will allow easier identification by the user when multiple calculations are saved.

Update `cctChange` to make the `endDate` property optional. In the case of LTFT any changes are for the remaining training duration, allowing a custom end date suggests that a temporary WTE change can be applied for.

TIS21-6544