### PR TITLE
feat: indicative CCT date and modification timestamps

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -154,6 +154,14 @@ components:
           type: string
           format: uuid
           example: "2861fb68-6c08-4af5-a3a1-6f561a37b406"
+        created:
+          type: string
+          format: date
+          readOnly: true
+        lastModified:
+          type: string
+          format: date
+          readOnly: true
     cctCalculationDetail:
       type: object
       required:
@@ -177,6 +185,14 @@ components:
           items: {
             $ref: "#/components/schemas/cctChange"
           }
+        created:
+          type: string
+          format: date
+          readOnly: true
+        lastModified:
+          type: string
+          format: date
+          readOnly: true
     cctChange:
       type: object
       required:

--- a/openapi.yml
+++ b/openapi.yml
@@ -178,6 +178,11 @@ components:
           description: A custom name for the calculation to aid identification.
           type: string
           example: "Parental leave + reduced hours"
+        cctDate:
+          description: Indicative CCT date
+          type: string
+          format: date
+          readOnly: true
         programmeMembership:
           $ref: "#/components/schemas/programmeMembership"
         changes:
@@ -213,6 +218,8 @@ components:
         wte:
           type: number
           format: percent
+          minimum: 0
+          maximum: 1
     programmeMembership:
       type: object
       required:
@@ -238,6 +245,8 @@ components:
         wte:
           type: number
           format: percent
+          minimum: 0
+          maximum: 1
     validationError:
       type: object
       readOnly: true


### PR DESCRIPTION
# feat: add create and modify timestamps to CCT calc
Add `created` and `lastModified` timestamps to the CCT calculation
response.

# feat: add cctDate field to CCT calc
Add a `cctDate` field to the CCT calculation detail response.

TIS21-6544