### PR TITLE
feat: add ltft data to dtos

### DIFF
--- a/openapi/components/schemas/CctCalculationDetail.yml
+++ b/openapi/components/schemas/CctCalculationDetail.yml
@@ -26,9 +26,9 @@ properties:
       $ref: ./CctChange.yml
   created:
     type: string
-    format: date
+    format: date-time
     readOnly: true
   lastModified:
     type: string
-    format: date
+    format: date-time
     readOnly: true

--- a/openapi/components/schemas/CctCalculationSummary.yml
+++ b/openapi/components/schemas/CctCalculationSummary.yml
@@ -17,11 +17,15 @@ properties:
     type: string
     format: uuid
     example: 2861fb68-6c08-4af5-a3a1-6f561a37b406
+  changes:
+    type: array
+    items:
+      $ref: ./CctChange.yml
   created:
     type: string
-    format: date
+    format: date-time
     readOnly: true
   lastModified:
     type: string
-    format: date
+    format: date-time
     readOnly: true

--- a/openapi/components/schemas/CctChange.yml
+++ b/openapi/components/schemas/CctChange.yml
@@ -3,6 +3,11 @@ required:
   - type
   - startDate
 properties:
+  id:
+    type: string
+    format: uuid
+    example: b2f8df7b-82f6-413f-8265-35a008d6b53b
+    readOnly: true
   type:
     type: string
     enum:

--- a/openapi/components/schemas/LtftApplicationDetail.yml
+++ b/openapi/components/schemas/LtftApplicationDetail.yml
@@ -12,10 +12,62 @@ properties:
     description: A custom reference for the LTFT application to aid identification.
     type: string
     example: My Programme - Hours Reduction
-  programmeMembershipId:
-    type: string
-    format: uuid
-    example: 2861fb68-6c08-4af5-a3a1-6f561a37b406
+  change:
+    allOf:
+      - required:
+          - calculationId
+          - cctDate
+      - properties:
+          calculationId:
+            type: string
+            format: uuid
+          cctDate:
+            type: string
+            format: date
+      - $ref: ./CctChange.yml
+  discussions:
+    required:
+      - discussedWithTpd
+      - tpdName
+      - tpdEmail
+    properties:
+      discussedWithTpd:
+        type: boolean
+      tpdName:
+        type: string
+        example: A. N. Other
+      tpdEmail:
+        type: string
+        format: email
+        example: a.n.other@example.com
+      other:
+        type: array
+        items:
+          type: object
+          required:
+            - name
+            - email
+            - role
+          properties:
+            name:
+              type: string
+              example: Jo Bloggs
+            email:
+              type: string
+              format: email
+              example: jo.bloggs@example.com
+            role:
+              type: string
+              example: Educational Supervisor
+  personalDetails:
+    $ref: ./PersonalDetails.yml
+  programmeMembership:
+    $ref: ./CctProgrammeMembership.yml
+  reasons:
+    type: array
+    items:
+      type: string
+      example: ["Caring Responsibilities", "Custom Reason"]
   status:
     type: object
     readOnly: true
@@ -31,12 +83,12 @@ properties:
               $ref: ../properties/FormStatus.yml
             timestamp:
               type: string
-              format: date
+              format: date-time
   created:
     type: string
-    format: date
+    format: date-time
     readOnly: true
   lastModified:
     type: string
-    format: date
+    format: date-time
     readOnly: true

--- a/openapi/components/schemas/LtftApplicationDetail.yml
+++ b/openapi/components/schemas/LtftApplicationDetail.yml
@@ -25,14 +25,26 @@ properties:
             type: string
             format: date
       - $ref: ./CctChange.yml
-  discussions:
+  declarations:
     required:
       - discussedWithTpd
-      - tpdName
-      - tpdEmail
+      - informationIsCorrect
+      - notGuaranteed
     properties:
       discussedWithTpd:
         type: boolean
+        description: Confirmation that the requested change has been discussed with their TPD.
+      informationIsCorrect:
+        type: boolean
+        description: Confirmation that all information given is correct.
+      notGuaranteed:
+        type: boolean
+        description: Understands that LTFT approval is not guaranteed.
+  discussions:
+    required:
+      - tpdName
+      - tpdEmail
+    properties:
       tpdName:
         type: string
         example: A. N. Other

--- a/openapi/components/schemas/LtftApplicationDetail.yml
+++ b/openapi/components/schemas/LtftApplicationDetail.yml
@@ -41,36 +41,28 @@ properties:
         type: boolean
         description: Understands that LTFT approval is not guaranteed.
   discussions:
-    required:
-      - tpdName
-      - tpdEmail
-    properties:
-      tpdName:
-        type: string
-        example: A. N. Other
-      tpdEmail:
-        type: string
-        format: email
-        example: a.n.other@example.com
-      other:
-        type: array
-        items:
-          type: object
-          required:
-            - name
-            - email
-            - role
-          properties:
-            name:
-              type: string
-              example: Jo Bloggs
-            email:
-              type: string
-              format: email
-              example: jo.bloggs@example.com
-            role:
-              type: string
-              example: Educational Supervisor
+    type: array
+    items:
+      type: object
+      required:
+        - name
+        - email
+        - role
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+    example:
+      - name: A. N. Other
+        email: a.n.other@example.com
+        role: Training Programme Director
+      - name: Jo Bloggs
+        email: jo.bloggs@example.com
+        role: Educational Supervisor
   personalDetails:
     $ref: ./PersonalDetails.yml
   programmeMembership:

--- a/openapi/components/schemas/LtftApplicationSummary.yml
+++ b/openapi/components/schemas/LtftApplicationSummary.yml
@@ -5,7 +5,7 @@ properties:
     type: string
     format: uuid
     example: fc13458c-5b0b-442f-8907-6f9af8fc0ffb
-  reference:
+  name:
     description: A custom reference for the LTFT application to aid identification.
     type: string
     example: My Programme - Hours Reduction
@@ -17,7 +17,7 @@ properties:
     $ref: ../properties/FormStatus.yml
   created:
     type: string
-    format: date
+    format: date-time
   lastModified:
     type: string
-    format: date
+    format: date-time

--- a/openapi/components/schemas/PersonalDetails.yml
+++ b/openapi/components/schemas/PersonalDetails.yml
@@ -1,11 +1,16 @@
 type: object
 required:
+  - id
   - title
   - forenames
   - surname
   - email
   - skilledWorkerVisaHolder
 properties:
+  id:
+    type: string
+    description: The person/trainee ID.
+    pattern: \d{1,7}
   title:
     type: string
     example: Mr

--- a/openapi/components/schemas/PersonalDetails.yml
+++ b/openapi/components/schemas/PersonalDetails.yml
@@ -1,0 +1,35 @@
+type: object
+required:
+  - title
+  - forenames
+  - surname
+  - email
+  - skilledWorkerVisaHolder
+properties:
+  title:
+    type: string
+    example: Mr
+  forenames:
+    type: string
+    example: Anthony
+  surname:
+    type: string
+    example: Gilliam
+  telephoneNumber:
+    type: string
+    example: 0161 4960000
+  mobileNumber:
+    type: string
+    example: 07700 900000
+  email:
+    type: string
+    format: email
+    example: anthony.gilliam@example.com
+  gmcNumber:
+    type: string
+    pattern: \d{7}
+  gdcNumber:
+    type: string
+    pattern: D\d{6}
+  skilledWorkerVisaHolder:
+    type: boolean


### PR DESCRIPTION
The DTO, as proposed:

```json
{
  "id": "fc13458c-5b0b-442f-8907-6f9af8fc0ffb",
  "name": "My Programme - Hours Reduction",
  "change": {
    "calculationId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
    "cctDate": "2025-01-14",
    "id": "b2f8df7b-82f6-413f-8265-35a008d6b53b",
    "type": "LTFT",
    "startDate": "2025-01-14",
    "endDate": "2025-01-14",
    "wte": 1
  },
  "declarations": {
    "discussedWithTpd": true,
    "informationIsCorrect": true,
    "notGuaranteed": true
  },
  "discussions": {
    "tpdName": "A. N. Other",
    "tpdEmail": "a.n.other@example.com",
    "other": [
      {
        "name": "Jo Bloggs",
        "email": "jo.bloggs@example.com",
        "role": "Educational Supervisor"
      }
    ]
  },
  "personalDetails": {
    "title": "Mr",
    "forenames": "Anthony",
    "surname": "Gilliam",
    "telephoneNumber": "0161 4960000",
    "mobileNumber": "07700 900000",
    "email": "anthony.gilliam@example.com",
    "gmcNumber": "3332804",
    "gdcNumber": "D409611",
    "skilledWorkerVisaHolder": true
  },
  "programmeMembership": {
    "id": "2861fb68-6c08-4af5-a3a1-6f561a37b406",
    "name": "General Practice",
    "startDate": "2025-01-14",
    "endDate": "2025-01-14",
    "wte": 1
  },
  "reasons": [
    [
      "Caring Responsibilities",
      "Custom Reason"
    ]
  ],
  "status": {
    "current": "DRAFT",
    "history": [
      {
        "status": "DRAFT",
        "timestamp": "2025-01-14T12:41:48.160Z"
      }
    ]
  },
  "created": "2025-01-14T12:41:48.160Z",
  "lastModified": "2025-01-14T12:41:48.160Z"
}
```

Some of the fields may be superfluous and need cleaning up, I reused some existing schemas for CctChanges and PMs so all the fields are currently included. 

Some specific points to consider:

1. `change` - I think the `calculationId` (and possible the `cctDate`) properties sitting within the `change` object makes sense but feels a little clunky. The calc ID feels like a "nice to have" though I'm not really sure how that or the change ID would be used in the future. Just feels easier to include and trim it off later rather than not have the "link" persisted.
2. `personalDetails` - I'm happy enough with this but there isn't a nice way to show conditionally required fields (i.e. at least one contact number and registration number) I tried a couple of approaches but it got messy quickly and there was a bug in the viewer that made it even more so. Another pass might be needed there, but the DTO structure itself won't change - just the docs.
3. `discussions` - I originally had `discussedWithTpd` here before moving it to `declarations`, which feels clearer. I'm still not convinced whether to have `tpdName`, `tpdEmail` and the `other` array vs a single `discussions` array and `TPD` just being a `role` on one of the entries.