### PR TITLE
feat: add LTFT admin GET endpoints

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,40 @@
+name: Deploy PR Preview to GitHub Pages
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    name: Deploy PR preview to GitHub pages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Build
+        if: github.event.action != 'closed'
+        run: npm install && npm run build
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./dist/
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This repository holds the OpenAPI documentation for the TIS Trainee API.
 
 The latest documentation is always available at [health-education-england.github.io/tis-trainee-api](https://health-education-england.github.io/tis-trainee-api/).
 
+Preview of open PRs are available by appending `/pr-preview/pr-{number}` to the end of the
+above path e.g. `health-education-england.github.io/tis-trainee-api/pr-preview/pr-123`.
+
 ## Developing
 
 ### Editing
@@ -12,7 +15,7 @@ The [API documentation](openapi.yml) can be worked on within any text editor or
 IDE. Plugins are available for several popular IDEs.
 
 ### Previewing
-Several options are provided for previewing the documentation
+Several options are provided for previewing the documentation.
 
 #### Docker
 A [Docker compose](docker-compose.yml) file is provided for ease of use, the

--- a/openapi/components/schemas/LtftApplicationAdminSummary.yml
+++ b/openapi/components/schemas/LtftApplicationAdminSummary.yml
@@ -18,6 +18,9 @@ properties:
   submissionDate:
     type: string
     format: date
+  reason:
+    type: string
+    example: Caring responsibilities
   daysToStart:
     type: number
   shortNotice:
@@ -37,5 +40,11 @@ properties:
   status:
     $ref: ../properties/FormStatus.yml
   assignedAdmin:
-    type: string
-    example: Ad Min
+    type: object
+    properties:
+      name:
+        type: string
+        example: Ad Min
+      email:
+        type: string
+        format: email

--- a/openapi/components/schemas/LtftApplicationAdminSummary.yml
+++ b/openapi/components/schemas/LtftApplicationAdminSummary.yml
@@ -1,0 +1,41 @@
+type: object
+readOnly: true
+properties:
+  id:
+    type: string
+    format: uuid
+    example: fc13458c-5b0b-442f-8907-6f9af8fc0ffb
+  personalDetails:
+    allOf:
+      - $ref: ./PersonalDetailsName.yml
+      - $ref: ./PersonalDetailsRegistration.yml
+  programmeName:
+    type: string
+    example: General Practice
+  proposedStartDate:
+    type: string
+    format: date
+  submissionDate:
+    type: string
+    format: date
+  daysToStart:
+    type: number
+  shortNotice:
+    type: boolean
+  tpd:
+    type: object
+    required:
+      - tpdEmail
+      - tpdEmailStatus
+    properties:
+      email:
+        type: string
+        format: email
+      emailStatus:
+        type: string
+        enum: [SENT, BOUNCED, REJECTED]
+  status:
+    $ref: ../properties/FormStatus.yml
+  assignedAdmin:
+    type: string
+    example: Ad Min

--- a/openapi/components/schemas/PageMetadata.yml
+++ b/openapi/components/schemas/PageMetadata.yml
@@ -1,0 +1,29 @@
+type: object
+required:
+  - page
+readOnly: true
+properties:
+  page:
+    type: object
+    required:
+      - size
+      - number
+      - totalElements
+      - totalPages
+    properties:
+      size:
+        type: number
+        description: The number of results per page.
+        example: 25
+      number:
+        type: number
+        description: The current page number.
+        example: 4
+      totalElements:
+        type: number
+        description: The total number of results.
+        example: 213
+      totalPages:
+        type: number
+        description: The total number of pages.
+        example: 9

--- a/openapi/components/schemas/PersonalDetails.yml
+++ b/openapi/components/schemas/PersonalDetails.yml
@@ -1,40 +1,27 @@
 type: object
-required:
-  - id
-  - title
-  - forenames
-  - surname
-  - email
-  - skilledWorkerVisaHolder
-properties:
-  id:
-    type: string
-    description: The person/trainee ID.
-    pattern: \d{1,7}
-  title:
-    type: string
-    example: Mr
-  forenames:
-    type: string
-    example: Anthony
-  surname:
-    type: string
-    example: Gilliam
-  telephoneNumber:
-    type: string
-    example: 0161 4960000
-  mobileNumber:
-    type: string
-    example: 07700 900000
-  email:
-    type: string
-    format: email
-    example: anthony.gilliam@example.com
-  gmcNumber:
-    type: string
-    pattern: \d{7}
-  gdcNumber:
-    type: string
-    pattern: D\d{6}
-  skilledWorkerVisaHolder:
-    type: boolean
+allOf:
+  - required:
+    - id
+    - email
+    - skilledWorkerVisaHolder
+  - properties:
+      id:
+        type: string
+        description: The person/trainee ID.
+        pattern: \d{1,7}
+  - $ref: ./PersonalDetailsName.yml
+  - properties:
+      telephoneNumber:
+        type: string
+        example: 0161 4960000
+      mobileNumber:
+        type: string
+        example: 07700 900000
+      email:
+        type: string
+        format: email
+        example: anthony.gilliam@example.com
+  - $ref: ./PersonalDetailsRegistration.yml
+  - properties:
+      skilledWorkerVisaHolder:
+        type: boolean

--- a/openapi/components/schemas/PersonalDetailsName.yml
+++ b/openapi/components/schemas/PersonalDetailsName.yml
@@ -1,0 +1,15 @@
+type: object
+required:
+  - title
+  - forenames
+  - surname
+properties:
+  title:
+    type: string
+    example: Mr
+  forenames:
+    type: string
+    example: Anthony
+  surname:
+    type: string
+    example: Gilliam

--- a/openapi/components/schemas/PersonalDetailsRegistration.yml
+++ b/openapi/components/schemas/PersonalDetailsRegistration.yml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  gmcNumber:
+    type: string
+    pattern: \d{7}
+  gdcNumber:
+    type: string
+    pattern: D\d{6}

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -27,6 +27,8 @@ paths:
     $ref: paths/forms_ltft_{formId}_unsubmit.yml
   /forms/ltft/{formId}/withdraw:
     $ref: paths/forms_ltft_{formId}_withdraw.yml
+  /forms/ltft/admin:
+    $ref: paths/forms_ltft_admin.yml
   /trainee/cct/calculation:
     $ref: paths/trainee_cct_calculation.yml
   /trainee/cct/calculation/{calculationId}:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -19,6 +19,8 @@ servers:
 paths:
   /forms/admin/ltft:
     $ref: paths/forms_admin_ltft.yml
+  /forms/admin/ltft/count:
+    $ref: paths/forms_admin_ltft_count.yml
   /forms/ltft:
     $ref: paths/forms_ltft.yml
   /forms/ltft/{formId}:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -17,6 +17,8 @@ servers:
   - url: https://trainee.tis.nhs.uk/api
     description: TIS Self-Service
 paths:
+  /forms/admin/ltft:
+    $ref: paths/forms_admin_ltft.yml
   /forms/ltft:
     $ref: paths/forms_ltft.yml
   /forms/ltft/{formId}:
@@ -27,8 +29,6 @@ paths:
     $ref: paths/forms_ltft_{formId}_unsubmit.yml
   /forms/ltft/{formId}/withdraw:
     $ref: paths/forms_ltft_{formId}_withdraw.yml
-  /forms/ltft/admin:
-    $ref: paths/forms_ltft_admin.yml
   /trainee/cct/calculation:
     $ref: paths/trainee_cct_calculation.yml
   /trainee/cct/calculation/{calculationId}:

--- a/openapi/paths/forms_admin_ltft.yml
+++ b/openapi/paths/forms_admin_ltft.yml
@@ -1,6 +1,6 @@
 get:
   summary: Return all LTFT applications for the admin's local office.
-  operationId: getLtftAdminSummaries
+  operationId: getAdminLtftSummaries
   parameters:
     - name: page
       in: query

--- a/openapi/paths/forms_admin_ltft_count.yml
+++ b/openapi/paths/forms_admin_ltft_count.yml
@@ -1,0 +1,22 @@
+get:
+  summary: Return a count of LTFT applications for the admin's local office.
+  operationId: getAdminLtftCount
+  parameters:
+    - name: status
+      in: query
+      description: The statuses to include in the count, defaults to all.
+      required: false
+      schema:
+        type: string
+        example: SUBMITTED,UNSUBMITTED
+  responses:
+    '200':
+      description: OK
+      content:
+        text/plain:
+          schema:
+            type: number
+            example: 40
+
+    '400':
+      description: Error getting LTFT count

--- a/openapi/paths/forms_ltft_admin.yml
+++ b/openapi/paths/forms_ltft_admin.yml
@@ -1,0 +1,36 @@
+get:
+  summary: Return all LTFT applications for the admin's local office.
+  operationId: getLtftAdminSummaries
+  parameters:
+    - name: page
+      in: query
+      description: The page you wish to retrieve.
+      required: false
+      schema:
+        type: integer
+        default: 0
+    - name: size
+      in: query
+      description: The size of the page to retrieve.
+      required: false
+      schema:
+        type: integer
+        default: 25
+    - name: sort
+      in: query
+      description: The field and direction to apply as a sort.
+      required: false
+      schema:
+        type: string
+        example: proposedStartDate,asc
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: ../components/schemas/LtftApplicationAdminSummary.yml
+    '400':
+      description: Error getting LTFT Summaries

--- a/openapi/paths/forms_ltft_admin.yml
+++ b/openapi/paths/forms_ltft_admin.yml
@@ -29,8 +29,13 @@ get:
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: ../components/schemas/LtftApplicationAdminSummary.yml
+            allOf:
+              - properties:
+                  content:
+                    type: array
+                    items:
+                      $ref: ../components/schemas/LtftApplicationAdminSummary.yml
+              - $ref: ../components/schemas/PageMetadata.yml
+
     '400':
       description: Error getting LTFT Summaries


### PR DESCRIPTION
# feat: add LTFT admin summary endpoint

Add the `/forms/ltft/admin` endpoint to return a summary list of LTFT
applications.

TIS21-6600

---

# feat: add count endpoint for LTFT admins

Add a `/forms/admin/ltft/count` endpoint to get the number of LTFT forms
associated with the Admin's local office.
An optional `status` query filter should be used to narrow the results
down, otherwise a count of all applications will be returned.

TIS21-6599