### PR TITLE
feat(cct): add DBC to CctProgrammeMembership

### DIFF
--- a/openapi/components/schemas/CctProgrammeMembership.yml
+++ b/openapi/components/schemas/CctProgrammeMembership.yml
@@ -13,6 +13,9 @@ properties:
   name:
     type: string
     example: General Practice
+  designatedBodyCode:
+    type: string
+    example: 1-1RSSQ1R
   startDate:
     type: string
     format: date


### PR DESCRIPTION
Include the ProgrammeMembership's Designated Body Code in the DTO to allow admin-facing LTFT endpoints to be filtered based on local office.

TIS21-6599
TIS21-6938