### PR TITLE
build: limit deploy clean up

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run bundle && webpack",
     "bundle": "redocly bundle openapi/openapi.yml --output dist/static/openapi.yml",
-    "deploy": "gh-pages -d dist",
+    "deploy": "gh-pages -d dist --remove static",
     "start": "npm run bundle && webpack serve --open",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
When deployed, all files are removed from the `gh-pages` branch and then re-created based on the current build.
This is removing temporary PR preview folders.

Limit the removal to just the `static` folder, which will cover the live docs without breaking PR previews.

NO-TICKET