### PR TITLE
feat(ltft): add admin endpoints for specific form

### DIFF
--- a/openapi/components/schemas/LtftApplicationAdminSummary.yml
+++ b/openapi/components/schemas/LtftApplicationAdminSummary.yml
@@ -5,6 +5,10 @@ properties:
     type: string
     format: uuid
     example: fc13458c-5b0b-442f-8907-6f9af8fc0ffb
+  formRef:
+    description: A human-friendly form reference.
+    type: string
+    example: ltft_47165_20250101_001
   personalDetails:
     allOf:
       - $ref: ./PersonalDetailsName.yml
@@ -40,11 +44,8 @@ properties:
   status:
     $ref: ../properties/FormStatus.yml
   assignedAdmin:
-    type: object
-    properties:
-      name:
-        type: string
-        example: Ad Min
-      email:
-        type: string
-        format: email
+    $ref: ./PersonRole.yml
+    example:
+        name: Ad Min
+        email: ad.min@example.com
+        role: ADMIN

--- a/openapi/components/schemas/LtftApplicationDetail.yml
+++ b/openapi/components/schemas/LtftApplicationDetail.yml
@@ -8,6 +8,10 @@ properties:
     format: uuid
     example: fc13458c-5b0b-442f-8907-6f9af8fc0ffb
     readOnly: true
+  formRef:
+    description: A human-friendly form reference.
+    type: string
+    example: ltft_47165_20250101_001
   name:
     description: A custom reference for the LTFT application to aid identification.
     type: string
@@ -56,22 +60,15 @@ properties:
       other:
         type: array
         items:
-          type: object
+          $ref: ./PersonRole.yml
           required:
             - name
             - email
             - role
-          properties:
-            name:
-              type: string
-              example: A. N. Other
-            email:
-              type: string
-              format: email
-              example: a.n.other@example.com
-            role:
-              type: string
-              example: Educational Supervisor
+          example:
+            name: Ed Super
+            email: ed.super@example.com
+            role: Eductional Supervisor
   personalDetails:
     $ref: ./PersonalDetails.yml
   programmeMembership:
@@ -92,17 +89,17 @@ properties:
     readOnly: true
     properties:
       current:
-        $ref: ../properties/FormStatus.yml
+        $ref: ./StatusInfo.yml
       history:
         type: array
         items:
-          type: object
-          properties:
-            status:
-              $ref: ../properties/FormStatus.yml
-            timestamp:
-              type: string
-              format: date-time
+          $ref: ./StatusInfo.yml
+  assignedAdmin:
+    $ref: ./PersonRole.yml
+    example:
+      name: Ad Min
+      email: ad.min@example.com
+      role: ADMIN
   created:
     type: string
     format: date-time

--- a/openapi/components/schemas/Person.yml
+++ b/openapi/components/schemas/Person.yml
@@ -1,0 +1,15 @@
+type: object
+description: A representation of a person associated with a trainee.
+required:
+  - name
+  - email
+properties:
+  name:
+    description: The full name of the person.
+    type: string
+    example: Anne Other
+  email:
+    description: The contact email of the person.
+    type: string
+    format: email
+    example: anne.other@example.com

--- a/openapi/components/schemas/PersonRole.yml
+++ b/openapi/components/schemas/PersonRole.yml
@@ -1,0 +1,9 @@
+type: object
+description: A representation of a person associated with a trainee and their role.
+allOf:
+  - $ref: ./Person.yml
+  - properties:
+      role:
+        description: The role of a person relative to a trainee.
+        type: string
+        example: Educational Supervisor

--- a/openapi/components/schemas/StatusDetail.yml
+++ b/openapi/components/schemas/StatusDetail.yml
@@ -1,0 +1,12 @@
+type: object
+required:
+  - reason
+properties:
+  reason:
+    description: The reason for the state change.
+    type: string
+    example: Proposed WTE %
+  message:
+    description: Additional information related to the state change.
+    type: string
+    example: Unable to accomodate lower than 60%

--- a/openapi/components/schemas/StatusInfo.yml
+++ b/openapi/components/schemas/StatusInfo.yml
@@ -1,0 +1,19 @@
+type: object
+readOnly: true
+properties:
+  state:
+    description: The lifecycle state.
+    $ref: ../properties/FormStatus.yml
+  detail:
+    description: Detail about the state transition.
+    $ref: ./StatusDetail.yml
+  modifiedBy:
+    description: The person who modified the status.
+    $ref: ./PersonRole.yml
+  timestamp:
+    description: The timestamp of the state change.
+    type: string
+    format: date-time
+  revision:
+    description: The current revision of the object, starting at 0.
+    type: number

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -21,6 +21,12 @@ paths:
     $ref: paths/forms_admin_ltft.yml
   /forms/admin/ltft/count:
     $ref: paths/forms_admin_ltft_count.yml
+  /forms/admin/ltft/{formId}:
+    $ref: paths/forms_admin_ltft_{formId}.yml
+  /forms/admin/ltft/{formId}/approve:
+    $ref: paths/forms_admin_ltft_{formId}_approve.yml
+  /forms/admin/ltft/{formId}/unsubmit:
+    $ref: paths/forms_admin_ltft_{formId}_unsubmit.yml
   /forms/ltft:
     $ref: paths/forms_ltft.yml
   /forms/ltft/{formId}:

--- a/openapi/paths/forms_admin_ltft_{formId}.yml
+++ b/openapi/paths/forms_admin_ltft_{formId}.yml
@@ -1,0 +1,20 @@
+get:
+  summary: Return the LTFT application with the given ID.
+  operationId: getLtftAdminDetail
+  parameters:
+    - name: formId
+      description: The ID of the LTFT application
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/LtftApplicationDetail.yml
+    '404':
+      description: LTFT application not found with matching ID, or the user does not have access

--- a/openapi/paths/forms_admin_ltft_{formId}_approve.yml
+++ b/openapi/paths/forms_admin_ltft_{formId}_approve.yml
@@ -1,6 +1,6 @@
 put:
-  summary: Update and submit an existing LTFT application.
-  operationId: submitLtftApplication
+  summary: Approve an existing submitted LTFT application.
+  operationId: approveLtft
   parameters:
     - name: formId
       description: The ID of the LTFT application
@@ -8,12 +8,14 @@ put:
       required: true
       schema:
         type: string
+        format: uuid
   requestBody:
+    description: The detail of the status change.
+    required: false
     content:
       application/json:
         schema:
-          $ref: ../components/schemas/LtftApplicationDetail.yml
-    required: true
+          $ref : ../components/schemas/StatusDetail.yml
   responses:
     '200':
       description: OK
@@ -28,9 +30,9 @@ put:
                       current:
                         properties:
                           state:
-                            example: SUBMITTED
+                            example: APPROVED
     '400':
-      description: LTFT application invalid
+      description: LTFT approval invalid
       content:
         application/problem+json:
           schema:
@@ -43,10 +45,8 @@ put:
                     items:
                       properties:
                         pointer:
-                          example: '#/name' # TODO: replace with actual field name
+                          example: '#/status/current/state'
                         detail:
-                          example: must not be null
-    '403':
-      description: Unknown trainee ID
+                          example: can not be transitioned to APPROVED
     '404':
-      description: LTFT application not found with matching ID, or requested LTFT application does not belong to the user
+      description: LTFT application not found with matching ID, or the user does not have access

--- a/openapi/paths/forms_admin_ltft_{formId}_unsubmit.yml
+++ b/openapi/paths/forms_admin_ltft_{formId}_unsubmit.yml
@@ -1,6 +1,6 @@
 put:
-  summary: Update and submit an existing LTFT application.
-  operationId: submitLtftApplication
+  summary: Unsubmit an existing submitted LTFT application.
+  operationId: unsubmitLtft
   parameters:
     - name: formId
       description: The ID of the LTFT application
@@ -8,12 +8,14 @@ put:
       required: true
       schema:
         type: string
+        format: uuid
   requestBody:
+    description: The detail of the status change.
+    required: true
     content:
       application/json:
         schema:
-          $ref: ../components/schemas/LtftApplicationDetail.yml
-    required: true
+          $ref : ../components/schemas/StatusDetail.yml
   responses:
     '200':
       description: OK
@@ -28,9 +30,9 @@ put:
                       current:
                         properties:
                           state:
-                            example: SUBMITTED
+                            example: UNSUBMITTED
     '400':
-      description: LTFT application invalid
+      description: LTFT unsubmission invalid
       content:
         application/problem+json:
           schema:
@@ -43,10 +45,8 @@ put:
                     items:
                       properties:
                         pointer:
-                          example: '#/name' # TODO: replace with actual field name
+                          example: '#/status/current/state'
                         detail:
-                          example: must not be null
-    '403':
-      description: Unknown trainee ID
+                          example: can not be transitioned to UNSUBMITTED
     '404':
-      description: LTFT application not found with matching ID, or requested LTFT application does not belong to the user
+      description: LTFT application not found with matching ID, or the user does not have access

--- a/openapi/paths/forms_ltft_{formId}_unsubmit.yml
+++ b/openapi/paths/forms_ltft_{formId}_unsubmit.yml
@@ -20,7 +20,9 @@ put:
                   status:
                     properties:
                       current:
-                        example: UNSUBMITTED
+                        properties:
+                          state:
+                            example: UNSUBMITTED
     '400':
       description: LTFT unsubmission invalid
       content:

--- a/openapi/paths/forms_ltft_{formId}_withdraw.yml
+++ b/openapi/paths/forms_ltft_{formId}_withdraw.yml
@@ -20,7 +20,9 @@ put:
                   status:
                     properties:
                       current:
-                        example: WITHDRAWN
+                        properties:
+                          state:
+                            example: WITHDRAWN
     '400':
       description: LTFT withdrawl invalid
       content:


### PR DESCRIPTION
Add the admin-facing endpoints for actions on a specific form, i.e.
- /forms/admin/ltft/{formId}
- /forms/admin/ltft/{formId}/approve
- /forms/admin/ltft/{formId}/unsubmit

Add the missing `formRef` field to the admin summary and details.

Extract person and status properties in to
 - Person
 - PersonRole
 - StatusInfo
 - StatusDetail

Update the lifecycle state property example for trainee-facing submit, unsubmit and withdraw endpoints to ensure that the response shows the expected status.

TIS21-6540